### PR TITLE
Add delay before firing route change to prevent mismatch

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -12,5 +12,6 @@ const prodHandler = () => {
   window.analytics && window.analytics.page()
 }
 
+// Adding a 50ms delay ensure that the segment route tracking is in sync with the actual Gatsby route (otherwise you can end up in a state where the Segment page tracking reports the previous page on route change).
 exports.onRouteUpdate =
-  process.env.NODE_ENV === "production" ? prodHandler : devHandler
+  setTimeout(() => process.env.NODE_ENV === "production" ? prodHandler : devHandler, 50)


### PR DESCRIPTION
@coreyward I saw this in https://github.com/benjaminhoffman/gatsby-plugin-segment-js/pull/30 and thought it'd be a worthwhile addition here - as I'm running into that issue myself.