### PR TITLE
Parameterize Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ module.exports = {
       resolve: "gatsby-plugin-segment-analytics",
       options: {
         writeKey: "YOUR WRITE KEY",
+
+        // Note: if no eventName is provided then the eventName will be set to
+        // "Page" in development mode (viewable from the console) and will be omitted
+        // in production. The properties object will still be automatically populated
+        // by segment's Analytics.js snippet.
+        eventName: "YOUR PAGE EVENT NAME",
       },
     },
   ],
@@ -69,6 +75,21 @@ export default () => {
     </OutboundLink>
   </div>
 }
+```
+
+You can optionally provide an `eventName` and `categoryName` prop to
+OutboundLink. This will change the segment event name (which is defaulted to
+"Click"), and the category name (which is a property of the segment event),
+respectively.
+
+```js
+<OutboundLink
+  href="https://www.gatsbyjs.org/packages/gatsby-plugin-segment-analytics/"
+  eventName="Visit External Link"
+  categoryName="Gatsby Resource"
+>
+  Visit the Segment Analytics plugin page!
+</OutboundLink>
 ```
 
 ## Special Thanks

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ export default () => {
 You can optionally provide an `eventName` and `categoryName` prop to
 OutboundLink. This will change the segment event name (which is defaulted to
 "Click"), and the category name (which is a property of the segment event),
-respectively.
+respectively. More information on the segment page event can be found
+[here](https://segment.com/docs/connections/spec/page/)
 
 ```js
 <OutboundLink

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,3 +1,5 @@
+const EVENT_NAME = process.env.PAGE_EVENT_NAME
+
 const devHandler = ({ location }) => {
   if (!window.analytics || typeof window.analytics.page !== "function") {
     console.warn("Unable to locate analytics.js")
@@ -5,16 +7,13 @@ const devHandler = ({ location }) => {
   }
 
   // This doesn't mimic the call to page, but it is more informative
-  window.analytics.page(
-    process.env.PAGE_EVENT_NAME ? process.env.PAGE_EVENT_NAME : "Page",
-    {
-      path: location.pathname,
-    }
-  )
+  window.analytics.page(EVENT_NAME ? EVENT_NAME : "Page", {
+    path: location.pathname,
+  })
 }
 
 const prodHandler = () => {
-  window.analytics && window.analytics.page(process.env.PAGE_EVENT_NAME)
+  window.analytics && window.analytics.page(EVENT_NAME)
 }
 
 exports.onRouteUpdate =

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -5,11 +5,11 @@ const devHandler = ({ location }) => {
   }
 
   // This doesn't mimic the call to page, but it is more informative
-  window.analytics.page({ path: location.pathname })
+  window.analytics.page("Blog Page", { path: location.pathname })
 }
 
 const prodHandler = () => {
-  window.analytics && window.analytics.page()
+  window.analytics && window.analytics.page("Blog Page")
 }
 
 exports.onRouteUpdate =

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,19 +1,17 @@
-const EVENT_NAME = process.env.PAGE_EVENT_NAME
-
-const devHandler = ({ location }) => {
+const devHandler = ({ location }, { eventName }) => {
   if (!window.analytics || typeof window.analytics.page !== "function") {
     console.warn("Unable to locate analytics.js")
     return
   }
 
   // This doesn't mimic the call to page, but it is more informative
-  window.analytics.page(EVENT_NAME ? EVENT_NAME : "Page", {
+  window.analytics.page(eventName ? eventName : "Page", {
     path: location.pathname,
   })
 }
 
-const prodHandler = () => {
-  window.analytics && window.analytics.page(EVENT_NAME)
+const prodHandler = (_, { eventName }) => {
+  window.analytics && window.analytics.page(eventName)
 }
 
 exports.onRouteUpdate =

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -5,11 +5,16 @@ const devHandler = ({ location }) => {
   }
 
   // This doesn't mimic the call to page, but it is more informative
-  window.analytics.page("Blog Page", { path: location.pathname })
+  window.analytics.page(
+    process.env.PAGE_EVENT_NAME ? process.env.PAGE_EVENT_NAME : "Page",
+    {
+      path: location.pathname,
+    }
+  )
 }
 
 const prodHandler = () => {
-  window.analytics && window.analytics.page("Blog Page")
+  window.analytics && window.analytics.page(process.env.PAGE_EVENT_NAME)
 }
 
 exports.onRouteUpdate =

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ function OutboundLink(props) {
   return (
     <a
       {...props}
-      onClick={e => {
+      onClick={(e) => {
         if (typeof props.onClick === `function`) {
           props.onClick(e)
         }
@@ -25,9 +25,11 @@ function OutboundLink(props) {
         }
         if (window.analytics) {
           window.analytics.track(
-            "Click",
+            props.eventName ? props.eventName : "Click",
             {
-              category: `Outbound Link`,
+              category: props.categoryName
+                ? props.categoryName
+                : `Outbound Link`,
               label: props.href,
             },
             null,
@@ -53,6 +55,8 @@ OutboundLink.propTypes = {
   href: PropTypes.string,
   target: PropTypes.string,
   onClick: PropTypes.func,
+  eventName: PropTypes.string,
+  categoryName: PropTypes.string,
 }
 
 export { OutboundLink }


### PR DESCRIPTION
This allows users to change the event and category name in the `OutboundLink` component (while maintaining sane defaults)

It also parameterizes the Page event using an environment variable (also defaulted)